### PR TITLE
Removed unfinished text from methodology page

### DIFF
--- a/methodology.html
+++ b/methodology.html
@@ -77,7 +77,10 @@
 
                 <hr/>
 								<h2 id="acquisition">Acquisition</h2>
-								<p>Eviction data is not publicly available, [reasoning why this may be so, explanation of how sparse resources to analyze this are, etc]</p>
+								<p>
+								  (Coming soon)
+								  <!-- Eviction data is not publicly available, [reasoning why this may be so, explanation of how sparse resources to analyze this are, etc] -->
+								</p>
 								<h3>Data providers:</h3>
 								<ol>
 								  <li><b>Legal Services Corporation</b>


### PR DESCRIPTION
In the **Acquisition** section, we had said: _Eviction_ data is not publicly available, [reasoning why this may be so, explanation of how sparse resources to analyze this are, etc]_. I commented this out and instead say _(Coming soon)_ so we don't have unfinished text on the actual website.