### PR TITLE
Added Other Research tab to index.html and cleaned up research.html code

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,6 +43,7 @@
 											<!-- <li><a href="">News</a></li> -->
 											<li><a href="methodology.html">Methodology</a></li>
 											<li><a href="resources.html">Eviction Help</a></li>
+											<li><a href="research.html">Other Research</a></li>
 											<li><a href="mailto:evictions@berkeley.edu?Subject=Contact%20through%20Evictions%20Study%20website">Contact us</a></li>
 											<!-- <li><a href="about.html">About</a></li> -->
 										</ul>

--- a/methodology.html
+++ b/methodology.html
@@ -40,10 +40,10 @@
 										<li><a href="methodology.html">Methodology</a></li>
 										<li><a href="resources.html">Eviction help</a></li>
 										<li><a href="mailto:evictions@berkeley.edu?Subject=Contact%20through%20Evictions%20Study%20website">Contact us</a></li>
+										<li><a href="research.html">Other Research</a></li>
 				  						<!--<li><a href="">State Maps</a></li>
 										<li><a href="">Reports</a></li>
 										<li><a href="news.html">News</a></li>
-				  						<li><a href="research.html">Research</a></li>
 				  						<li><a href="about.html">About</a></li>-->
 									</ul>
 								</div>

--- a/research.html
+++ b/research.html
@@ -46,7 +46,7 @@
 				  						<!-- <li><a href="">State Maps</a></li>
 										<li><a href="">Reports</a></li>
 										<li><a href="news.html">News</a></li> -->
-				  						<li><a href="research.html">Research</a></li>
+				  						<li><a href="research.html">Other Research</a></li>
 				  						<!-- <li><a href="about.html">About</a></li> -->
 									</ul>
 								</div>
@@ -70,304 +70,332 @@
 							<h4>Table of Contents</h4>
 							  <ul>
 							    <li><a href = "#national">National (not state-specific)</a></li>
-								<li><i>Available states:</i>
-									<ul>
-					                  <li><a href="#delaware">Delaware</a></li>
-					                  <li><a href="#indiana">Indiana</a></li>
-					                  <li><a href="#illinois">Illinois</a></li>
-					                  <li><a href="#minnesota">Minnesota</a></li>
-					                  <li><a href="#missouri">Missouri</a></li>
-					                  <li><a href="#ohio">Ohio</a></li>
-					                  <li><a href="#oregon">Oregon</a></li>
-					                  <li><a href="#pennsylvania">Pennsylvania</a></li>
-					                  <li><a href="#texas">Texas</a></li>
-									</ul>
-				                </li>
-			               	 </ul>
+								  <li><i>Available states:</i>
+									  <ul>
+									    <li><a href="#delaware">Delaware</a></li>
+					            <li><a href="#illinois">Illinois</a></li>
+  					          <li><a href="#indiana">Indiana</a></li>
+  					          <li><a href="#minnesota">Minnesota</a></li>
+  					          <li><a href="#missouri">Missouri</a></li>
+  					          <li><a href="#ohio">Ohio</a></li>
+  					          <li><a href="#oregon">Oregon</a></li>
+  					          <li><a href="#pennsylvania">Pennsylvania</a></li>
+  					          <li><a href="#texas">Texas</a></li>
+									  </ul>
+				          </li>
+			          </ul>
+			          
 							<hr>
 <!-- National Studies -->
 							<h2 id="national">National</h2>
 								<p>
-								  <a href="https://nap.nationalacademies.org/catalog/26106/rental-eviction-and-the-covid-19-pandemic-averting-a-looming" target="_blank"><b>Rental Eviction and the COVID-19 Pandemic: Averting a Looming Crisis</b></a><br>
+								  <a href="https://nap.nationalacademies.org/catalog/26106/rental-eviction-and-the-covid-19-pandemic-averting-a-looming" target="_blank">
+								    <b>Rental Eviction and the COVID-19 Pandemic: Averting a Looming Crisis</b>
+								  </a>
+								  <br>
 								  <i>National Academies of Science, Engineering, & Medicine (2022)</i>
 								</p>
 								<p>
-								  <a href="https://www.huduser.gov/portal/sites/default/files/pdf/EM-Newsletter-Summer2021.pdf" target="_blank"><b>Evidence Matters: Evictions</b></a><br>
+								  <a href="https://www.huduser.gov/portal/sites/default/files/pdf/EM-Newsletter-Summer2021.pdf" target="_blank">
+								    <b>Evidence Matters: Evictions</b>
+								  </a>
+								  <br>
 								  <i>HUD Office of Policy Development and Research (2021)</i>
 								</p>
+								
 							<hr>
-<!-- State Studies -->
-							<h2 id="indiana">Indiana</h2>
+<!-- State Studies -->							
+              <h2 id="delaware">Delaware</h2>
 								<p>
-									<a href="https://policyinstitute.iu.edu/doc/Evictions-2020-Brief_CRISP_Feb.15.2021_ACCESSIBLE.pdf" target="_blank"><b>Housing Instability in Marion County Evictions Before and During COVID-19</b></a><br>
-									<i>Indiana University, Public Policy Institute, Center for Research on Inclusion & Social Policy (2021)</i>
-								</p>
-								<p>
-									<a href="https://mckinneylaw.iu.edu/practice/clinics/_docs/Indiana_courts_prevent_evictions.pdf" targe="_blank"><b>How Indiana Courts Can Prevent Evictions: Responding to a Looming Public Health and Economic Crisis</b></a><br>
-									<i>Health and Human Rights Clinic, Indiana University, McKinney School of Law, The Indiana Justice Project, Notre Dame Clinical Law Center (2021)</i>
-								</p>
-								<p>
-									<a href="https://heinonline.org/HOL/Page?handle=hein.journals/indilr46&id=1383&collection=journals&index=" targe="_blank"><b>Insuring the Effectiveness of Indiana’s Landlord-Tenant Laws: The Necessity of Recognizing the Doctrine of Retaliatory Eviction In Indiana</b></a><br>
-									<i>Brian D. Casserly (2013)</i>
-								</p>
-							<hr>
-                			<h2 id="delaware">Delaware</h2>
-								<p>
-									<a href="https://www.homescampaignde.org/news-and-academic-articles" target="_blank"><b>Housing Opportunity Mobility Equity Stability (H.O.M.E.S.) Campaign: List of Latest Stories and Research</b></a><br>
+									<a href="https://www.homescampaignde.org/news-and-academic-articles" target="_blank">
+									  <b>Housing Opportunity Mobility Equity Stability (H.O.M.E.S.) Campaign: List of Latest Stories and Research</b>
+									</a>
+									<br>
 									<i>Updated frequently</i>
 								</p>
-                				<p>
-									<a href="https://djph.org/wp-content/uploads/2022/09/djph-83-009.pdf" targe="_blank"><b>Prior Evictions Among People Experiencing Homelessness in Delaware</b></a><br>
+                <p>
+									<a href="https://djph.org/wp-content/uploads/2022/09/djph-83-009.pdf" targe="_blank">
+									  <b>Prior Evictions Among People Experiencing Homelessness in Delaware</b>
+									</a>
+									<br>
 									<i>Metraux S, Mwangi O, McGuire J. Prior Evictions Among People Experiencing Homelessness in Delaware. Dela J Public Health (2022)</i>
 								</p>
 								<p>
-									<a href="https://udspace.udel.edu/bitstream/handle/19716/25186/200330%20covid%20housing%20complete%20draft.pdf?sequence=1&isAllowed=y" targe="_blank"><b>Addressing the Threat of COVID-19 Related Housing Instability and Displacement in Delaware</b></a><br>
+									<a href="https://udspace.udel.edu/bitstream/handle/19716/25186/200330%20covid%20housing%20complete%20draft.pdf?sequence=1&isAllowed=y" targe="_blank">
+									  <b>Addressing the Threat of COVID-19 Related Housing Instability and Displacement in Delaware</b>
+									</a>
+									<br>
 									<i>Metraux S, Rayl M, O’Hanlon J, O’Neill S, Center for Community Research and Service & Institute for Public Administration, Joseph R. Biden, Jr. School of Policy and Public Administration, University of Delaware (2020)</i>
 								</p>
 								<p>
 									<a href="https://udspace.udel.edu/bitstream/handle/19716/26352/CCRS%20Eviction%20Brief%20final%20v2.pdf?sequence=5&isAllowed=y" targe="_blank">
-									<b>Eviction and Legal Representation in Delaware - An Overview</b></a><br>
+									  <b>Eviction and Legal Representation in Delaware - An Overview</b>
+								  </a>
+									<br>
 									<i>Guterbock A, Metraux S, Biden School of Public Policy & Administration, University of Delaware (2020)</i>
 								</p>
+								
+							<hr>
+							<h2 id="illinois">Illinois</h2>
+								<p>
+									<a href="https://eviction.lcbh.org/reports">
+									  <b>Chicago Evictions</b>
+									</a>
+									<br>
+									<i>Lawyers’ Committee for Better Housing</i>
+								</p>
+								<p>
+									<a href="https://housingactionil.org/what-we-do/advocacy/eviction/">
+									  <b>Addressing Eviction: Eviction in Illinois</b>
+									</a>
+									<br>
+									<i>Housing Action Illinois</i>
+								</p>
+								<p>
+									<a href="https://papers.ssrn.com/sol3/papers.cfm?abstract_id=4247293">
+									  <b>Race and Eviction During the Pandemic</b>
+									</a>
+									<br>
+									<i>Gaines, Brian J. and Mazzone, Jason and Mettler, Matthew and Wilson, Robin Fretwell - Race and Eviction During the Pandemic (2022)</i>
+								</p>
+								<p>
+									<a href="https://pubmed.ncbi.nlm.nih.gov/33533076/">
+									  <b>Unhealthy Behaviors in Urban Illinois Communities Affected by Eviction: A Descriptive Analysis</b>
+									</a>
+									<br>
+									<i>Hazekamp C, Yousuf S, Khare M, MacDowell M. - Unhealthy behaviours in urban Illinois communities affected by eviction: A descriptive analysis (2021)</i>
+								</p>
+								<p>
+									<a href="https://publichealth.uic.edu/uic-covid-19-public-health-response/covid-19-maps-chicago-illinois/chicago-evictions-and-covid-19/">
+									  <b>Chicago Evictions and COVID-19</b>
+									</a>
+									<br>
+									<i>University of Illinois Chicago, School of Public Health</i>
+								</p>
+								
+							<hr>
+							<h2 id="indiana">Indiana</h2>
+								<p>
+									<a href="https://policyinstitute.iu.edu/doc/Evictions-2020-Brief_CRISP_Feb.15.2021_ACCESSIBLE.pdf" target="_blank">
+									  <b>Housing Instability in Marion County Evictions Before and During COVID-19</b>
+									</a>
+									<br>
+									<i>Indiana University, Public Policy Institute, Center for Research on Inclusion & Social Policy (2021)</i>
+								</p>
+								<p>
+									<a href="https://mckinneylaw.iu.edu/practice/clinics/_docs/Indiana_courts_prevent_evictions.pdf" targe="_blank">
+									  <b>How Indiana Courts Can Prevent Evictions: Responding to a Looming Public Health and Economic Crisis</b>
+									</a>
+									<br>
+									<i>Health and Human Rights Clinic, Indiana University, McKinney School of Law, The Indiana Justice Project, Notre Dame Clinical Law Center (2021)</i>
+								</p>
+								<p>
+									<a href="https://heinonline.org/HOL/Page?handle=hein.journals/indilr46&id=1383&collection=journals&index=" targe="_blank">
+									  <b>Insuring the Effectiveness of Indiana’s Landlord-Tenant Laws: The Necessity of Recognizing the Doctrine of Retaliatory Eviction In Indiana</b>
+									</a>
+									<br>
+									<i>Brian D. Casserly (2013)</i>
+								</p>
+								
 							<hr>
 							<h2 id="minnesota">Minnesota</h2>
 								<p>
 									<a href="https://evictions.cura.umn.edu/sites/evictions.cura.umn.edu/files/files/general/illusion-of-choice-full-report-web.pdf" targe="_blank">
-									<b>The Illusion of Choice: Evictions and Profit in North Minneapolis</b></a><br>
+									  <b>The Illusion of Choice: Evictions and Profit in North Minneapolis</b>
+							    </a>
+							    <br>
 									<i>Dr. Lewis B, Calhoun M, Matthias C, Conception K, Reyes T, Szczepanski C, Norton G, Noble E, and Tisdale G, Center for Urban and Regional Affairs, University of Minnesota (2021)</i>
 								</p>
 								<p>
-									<a href="https://view.ckcest.cn/AllFiles/ZKBG/Pages/984/preventing-eviction-filings-piloting-a-pre-filing-eviction-prevention-clinic.pdf" targe="_blank"><b>Preventing Eviction Filing: Piloting a Pre-filing Eviction Prevention Clinic</b></a><br>
+									<a href="https://view.ckcest.cn/AllFiles/ZKBG/Pages/984/preventing-eviction-filings-piloting-a-pre-filing-eviction-prevention-clinic.pdf" targe="_blank">
+									  <b>Preventing Eviction Filing: Piloting a Pre-filing Eviction Prevention Clinic</b>
+									</a>
+									<br>
 									<i>Cohen M, Noble E, Metropolitan Housing and Communities Policy Center, Urban Institute (2020)</i>
 								</p>
 								<p>
-									<a href="https://scholarship.law.umn.edu/cgi/viewcontent.cgi?article=1620&context=lawineq" targe="_blank"><b>Mitigating Power Imbalance in Eviction Mediation: A Model for Minnesota</b></a><br>
+									<a href="https://scholarship.law.umn.edu/cgi/viewcontent.cgi?article=1620&context=lawineq" targe="_blank">
+									  <b>Mitigating Power Imbalance in Eviction Mediation: A Model for Minnesota</b>
+									</a>
+									<br>
 									<i>Hare R, Law & Ineq. 135 (2020)</i>
 								</p>
 								<p>
 									<a href="https://www.mnhousing.gov/sites/np/research" targe="_blank">
-									<b>Minnesota Housing: Research on Housing and Community Needs</b></a><br>
+									  <b>Minnesota Housing: Research on Housing and Community Needs</b>
+									</a>
+									<br>
 									<i>(Last updated 2020)</i>
 								</p>
+								
 							<hr>
 							<h2 id="missouri">Missouri</h2>
 								<p>
 									<a href="https://www.evictionkc.org/project" targe="_blank">
-									<b>Kansas City Eviction Project </b></a>
+									  <b>Kansas City Eviction Project </b>
+								  </a>
 								</p>
 								<p>
 									<a href="https://www.stlouis-mo.gov/government/departments/mayor/initiatives/resilience/equity/justice/court-reform/evictions.cfm" targe="_blank">
-									<b>St. Louis, Justice For All - Evictions</b></a>
+									  <b>St. Louis, Justice For All - Evictions</b>
+									</a>
 								</p>
 								<p>
 									<a href="https://openscholarship.wustl.edu/cgi/viewcontent.cgi?article=2170&context=law_journal_law_policy" targe="_blank">
-									<b>Addressing the Eviction Crisis and Housing Instability Through Mediation </b></a><br>
+									  <b>Addressing the Eviction Crisis and Housing Instability Through Mediation </b>
+									</a>
+									<br>
 									<i>Karen Tokarz, Samuel Hoff Stragand, Michael Geigerman, and Wolf Smith, Addressing the Eviction Crisis and Housing Instability Through Mediation, 63 WASH. U. J. L. & POL’Y 243 (2020)</i>
 								</p>
 								<p>
 									<a href="https://www.aspeninstitute.org/wp-content/uploads/2020/08/Evictions-Data-Update-August.pdf" targe="_blank">
-									<b>National Eviction Risk Projections</b></a><br>
+									  <b>National Eviction Risk Projections</b>
+								  </a>
+								  <br>
 									<i>COVID-19 Eviction Defense Project, The Aspen Institute Financial Security Program (2020)</i>
 								</p>
 								<p>
-									<a href="https://mffh.org/wp-content/uploads/2020/09/Housing.pdf" targe="_blank"><b>Navigating COVID-19: Health Policy Solutions Housing</b></a><br>
+									<a href="https://mffh.org/wp-content/uploads/2020/09/Housing.pdf" targe="_blank">
+									  <b>Navigating COVID-19: Health Policy Solutions Housing</b>
+									</a>
+									<br>
 									<i>Amy Siegler, Missouri Foundation for Health (2020)</i>
 								</p>
+								
+							<hr>
+							<h2 id="ohio">Ohio</h2>
+								<p>
+									<a href="https://journals.sagepub.com/doi/full/10.1177/0002716221991458">
+									  <b>The Concentrated Geography of Eviction</b>
+									</a>
+									<br>
+									<i>Devin Rutan, Matthew Desmond (2021)</i>
+								</p>
+								<p>
+									<a href="https://cohhio.org/report-highlights-evictions-during-the-pandemic/">
+									  <b>Advocates Warn of Post-Moratorium Spike</b>
+									</a>
+									<br>
+									<i>Coalition on Homelessness and Housing in Ohio</i>
+								</p>
+								<p>
+									<a href="https://www.clevelandfed.org/topics/housing/mmst-20210504-evictions">
+									  <b>The Threat of Eviction during COVID-19: Perspectives from Cleveland’s Ohio City</b>
+									</a>
+									<br>
+									<i>Michelle Volpe-Kohler, Federal Reserve Bank of Cleveland</i>
+								</p>
+								<p>
+									<a href="https://case.edu/socialwork/povertycenter/sites/case.edu.povertycenter/files/2019-11/The%20Cleveland%20Eviction%20Study-10242019-fully%20accessible%28r%29.pdf">
+									  <b>The Cleveland Eviction Study: Observations in Eviction Court and the Stories of Poeple Facing Eviction</b>
+									</a>
+									<br>
+									<i>April Hirsh Urban, Aleksandra Tyler, Francisca García-Cobián Richter, Claudia Coulton, Tsui Chan, Center on Urban Poverty and Community Development, Case Western Reserve University</i>
+								</p>
+								<p>
+									<a href="https://www.clevelandfed.org/publications/economic-commentary/2022/ec-202212-making-sense-of-eviction-trends-during-the-pandemic">
+									  <b>Making Sense of Eviction Trends during the Pandemic</b>
+									</a>
+									<br>
+									<i>Hal Martin</i>
+								</p>	
+								
 							<hr>
 							<h2 id="oregon">Oregon</h2>
 								<p>
-									<a href="https://www.evictedinoregon.com" targe="_blank"><b>Evicted in Oregon</b></a><br>
+									<a href="https://www.evictedinoregon.com" targe="_blank">
+									  <b>Evicted in Oregon</b>
+									</a>
+									<br>
 								</p>
 								<p>
-									<a href="https://www.pdx.edu/homelessness/evaluating-oregons-safe-harbor-eviction-diversion" targe="_blank"><b>Evaluating Oregon’s Safe Harbor Eviction Diversion</b></a><br>
+									<a href="https://www.pdx.edu/homelessness/evaluating-oregons-safe-harbor-eviction-diversion" targe="_blank">
+									  <b>Evaluating Oregon’s Safe Harbor Eviction Diversion</b>
+									</a>
+									<br>
 									<i>Lisa K. Bates, Colleen Carroll, Minji Cho, Devin MacArthur, Homelessness Research & Action Collaborative, Portland State University</i>
 								</p>
 								<p>
 									<a href="https://www.pdx.edu/homelessness/sites/g/files/znldhr1791/files/2021-12/Bates-Oregon%20Safe%20Harbor%20early%20implementation.pdf">
-									<b>Oregon's Safe Harbor for Tenants: Rocky Shoals In Eviction Diversion</b></a><br>
+									  <b>Oregon's Safe Harbor for Tenants: Rocky Shoals In Eviction Diversion</b>
+									</a>
+									<br>
 									<i>Lisa Bates, Housing Crisis Research Collaborative, Homelessness Research & Action Collaborative, Portland State University</i>
 								</p>
-								<hr>
-								<h2 id="pennsylvania">Pennsylvania</h2>
-								<p>
-									<a href="https://pittsburghfoundation.org/sites/default/files/Eviction%20in%20Allegheny%20County-a%20mixed%20methods%20study_0.pdf">
-									<b>Eviction In Allegheny County: A Mixed-Methods Study By The Pittsburgh Foundation
-									</b>
-									</a>
-									<br>
-									<i>The Pittsburgh Foundation (2021)
-                  </i>
-								</p>
+								
+							<hr>
+							<h2 id="pennsylvania">Pennsylvania</h2>
 								<p>
 									<a href="https://housingalliancepa.org/wp-content/uploads/Statewide-Eviction-Analysis_Housing-Alliance-of-PA_Feb-2022.pdf">
-									<b>Revealing Opportunities and Challenges: An Analysis of Eviction Filings in Pennsylvania
-									</b>
+									  <b>Revealing Opportunities and Challenges: An Analysis of Eviction Filings in Pennsylvania</b>
 									</a>
 									<br>
-									<i>The Housing Alliance of Pennsylvania (2022)
-                  </i>
+									<i>The Housing Alliance of Pennsylvania (2022)</i>
 								</p>
 								<p>
 									<a href="https://deliverypdf.ssrn.com/delivery.php?ID=311071073029064105080104003081126120035055026027031023101089115109004115092127124009003043120052118045043115123094125092117031013080071041077124097093002077016019007019004095094096068025010029126067099075068071093001019007065065105080081013105070117&EXT=pdf&INDEX=TRUE">
-									<b>Longer Trips to Court Cause Evictions
-									</b>
+									  <b>Longer Trips to Court Cause Evictions</b>
 									</a>
 									<br>
-									<i>Hoffman, David A. and Strezhnev, Anton - Longer Trips to Court Cause Evictions (2022)
-									</i>
+									<i>Hoffman, David A. and Strezhnev, Anton - Longer Trips to Court Cause Evictions (2022)</i>
 								</p>
+								<p>
+									<a href="https://pittsburghfoundation.org/sites/default/files/Eviction%20in%20Allegheny%20County-a%20mixed%20methods%20study_0.pdf">
+									  <b>Eviction In Allegheny County: A Mixed-Methods Study By The Pittsburgh Foundation</b>
+									</a>
+									<br>
+									<i>The Pittsburgh Foundation (2021)</i>
+								</p>								
 								<p>
 									<a href="https://www.reinvestment.com/wp-content/uploads/2019/10/ReinvestmentFund__PHL-Evictions-Brief-Oct-2019.pdf">
-									<b>Evictions in Philadelphia: A Data & Policy Update
-									</b>
+									  <b>Evictions in Philadelphia: A Data & Policy Update</b>
 									</a>
 									<br>
-									<i>Ira Goldstein, Emily Dowdall, Colin Weidig, Janine Simmons, Brian Carney, Policy Solutions, Reinvestment Fund
-									</i>
+									<i>Ira Goldstein, Emily Dowdall, Colin Weidig, Janine Simmons, Brian Carney, Policy Solutions, Reinvestment Fund (2019)</i>
 								</p>
-								<hr>
-								<h2 id="illinois">Illinois</h2>
-								<p>
-									<a href="https://eviction.lcbh.org/reports">
-									<b>Chicago Evictions
-									</b>
-									</a>
-									<br>
-									<i>Lawyers’ Committee for Better Housing
-									</i>
-								</p>
-								<p>
-									<a href="https://housingactionil.org/what-we-do/advocacy/eviction/">
-									<b>Addressing Eviction: Eviction in Illinois
-									</b>
-									</a>
-									<br>
-									<i>Housing Action Illinois
-									</i>
-								</p>
-								<p>
-									<a href="https://papers.ssrn.com/sol3/papers.cfm?abstract_id=4247293">
-									<b>Race and Eviction During the Pandemic
-									</b>
-									</a>
-									<br>
-									<i>Gaines, Brian J. and Mazzone, Jason and Mettler, Matthew and Wilson, Robin Fretwell - Race and Eviction During the Pandemic (2022)
-									</i>
-								</p>
-								<p>
-									<a href="https://pubmed.ncbi.nlm.nih.gov/33533076/">
-									<b>Unhealthy Behaviors in Urban Illinois Communities Affected by Eviction: A Descriptive Analysis
-									</b>
-									</a>
-									<br>
-									<i>Hazekamp C, Yousuf S, Khare M, MacDowell M. - Unhealthy behaviours in urban Illinois communities affected by eviction: A descriptive analysis (2021)
-									</i>
-								</p>
-								<p>
-									<a href="https://publichealth.uic.edu/uic-covid-19-public-health-response/covid-19-maps-chicago-illinois/chicago-evictions-and-covid-19/">
-									<b>Chicago Evictions and COVID-19
-									</b>
-									</a>
-									<br>
-									<i>University of Illinois Chicago, School of Public Health
-									</i>
-								</p>
-								<hr>
-								<h2 id="ohio">Ohio</h2>
-								<p>
-									<a href="https://journals.sagepub.com/doi/full/10.1177/0002716221991458">
-									<b>The Concentrated Geography of Eviction
-									</b>
-									</a>
-									<br>
-									<i>Devin Rutan, Matthew Desmond (2021)
-									</i>
-								</p>
-								<p>
-									<a href="https://cohhio.org/report-highlights-evictions-during-the-pandemic/">
-									<b>Advocates Warn of Post-Moratorium Spike
-									</b>
-									</a>
-									<br>
-									<i>Coalition on Homelessness and Housing in Ohio
-									</i>
-								</p>
-								<p>
-									<a href="https://www.clevelandfed.org/topics/housing/mmst-20210504-evictions">
-									<b>The Threat of Eviction during COVID-19: Perspectives from Cleveland’s Ohio City
-									</b>
-									</a>
-									<br>
-									<i>Michelle Volpe-Kohler, Federal Reserve Bank of Cleveland
-									</i>
-								</p>
-								<p>
-									<a href="https://case.edu/socialwork/povertycenter/sites/case.edu.povertycenter/files/2019-11/The%20Cleveland%20Eviction%20Study-10242019-fully%20accessible%28r%29.pdf">
-									<b>The Cleveland Eviction Study: Observations in Eviction Court and the Stories of Poeple Facing Eviction
-									</b>
-									</a>
-									<br>
-									<i>April Hirsh Urban, Aleksandra Tyler, Francisca García-Cobián Richter, Claudia Coulton, Tsui Chan, Center on Urban Poverty and Community Development, Case Western Reserve University
-									</i>
-								</p>
-								<p>
-									<a href="https://www.clevelandfed.org/publications/economic-commentary/2022/ec-202212-making-sense-of-eviction-trends-during-the-pandemic">
-									<b>Making Sense of Eviction Trends during the Pandemic
-									</b>
-									</a>
-									<br>
-									<i>Hal Martin
-									</i>
-								</p>
-								<hr>
-								<h2 id="texas">Texas</h2>
+								
+							<hr>
+							<h2 id="texas">Texas</h2>
 								<p>
 									<a href="https://urbanpolicyresearch.org/download/a-review-of-eviction-protections-in-dallas-texas/">
-									<b>A Review Of Eviction Protections In Dallas, Texas
-									</b>
+									  <b>A Review Of Eviction Protections In Dallas, Texas</b>
 									</a>
 									<br>
-									<i>Timothy Bray, The Institute for Urban Policy Research at the University of Texas at Dallas
-									</i>
+									<i>Timothy Bray, The Institute for Urban Policy Research at the University of Texas at Dallas (2021)</i>
 								</p>
+								<p>
+								  <a href="https://journals.sagepub.com/doi/abs/10.1177/0003122416688667">
+								    <b>Displaced in Place: Manufactured Housing, Mass Eviction, and the Paradox of State Intervention</b>
+								  </a>
+								  <br>
+								  <i>Esther Sullivan, Department of Sociology, University of Colorado Denver (2017)</i>
+								</p>								
 								<p>
 									<a href="https://commons.stmarytx.edu/cgi/viewcontent.cgi?article=1574&context=thestmaryslawjournal">
-									<b>Retaliatory Eviction in Texas - An Analysis and a Proposal
-									</b>
+									  <b>Retaliatory Eviction in Texas - An Analysis and a Proposal</b>
 									</a>
 									<br>
-									<i>Jane E. Bockus, St. Mary’s University
-									</i>
-								</p>
-								<p>
-								<a href="https://journals.sagepub.com/doi/abs/10.1177/0003122416688667">
-								<b>Displaced in Place: Manufactured Housing, Mass Eviction, and the Paradox of State Intervention
-								</b>
-								</a>
-								<br>
-								<i>Esther Sullivan, Department of Sociology, University of Colorado Denver
-								</i>
+									<i>Jane E. Bockus, St. Mary’s University (1978)</i>
 								</p>
 							</div>
 						</section>
 					</article>
 
-				<!-- Footer -->
-                <footer id="footer">
-                    <ul class="icons">
-                        <li><a href="https://twitter.com/EvictionNet" class="icon brands fa-twitter" target="_blank"><span class="label">Twitter</span></a></li>
-                        <li><a href="mailto:evictions@berkeley.edu?Subject=Contact%20through%20website" class="icon solid fa-envelope" target="_blank"><span class="label">Email</span></a></li>
-                    </ul>
-                    <div>
-                    <ul class="copyright">
-                        <li>&copy; 2022 The Eviction Research Network</li>
-                        <li><a href="https://urbandisplacement.org" target="_blank">urbandisplacement.org</a></li>
-                        <li>Design: <a href="http://html5up.net" target="_blank">HTML5 UP</a> & <a href="https://www.dannyrothschild.com" target="_blank">Danny Rothschild</a></li>							
+				  <!-- Footer -->
+          <footer id="footer">
+            <ul class="icons">
+              <li><a href="https://twitter.com/EvictionNet" class="icon brands fa-twitter" target="_blank"><span class="label">Twitter</span></a></li>
+              <li><a href="mailto:evictions@berkeley.edu?Subject=Contact%20through%20website" class="icon solid fa-envelope" target="_blank"><span class="label">Email</span></a></li>
+            </ul>
+            <div>
+              <ul class="copyright">
+                <li>&copy; 2022 The Eviction Research Network</li>
+                <li><a href="https://urbandisplacement.org" target="_blank">urbandisplacement.org</a></li>
+                <li>Design: <a href="http://html5up.net" target="_blank">HTML5 UP</a> & <a href="https://www.dannyrothschild.com" target="_blank">Danny Rothschild</a></li>	
+              </ul>
+          </footer>
 
-                    </ul>
-                </footer>
-
-			</div>
+			      </div>
 
 		<!-- Scripts -->
 			<script src="assets/js/jquery.min.js"></script>

--- a/resources.html
+++ b/resources.html
@@ -40,10 +40,10 @@
 											<li><a href="methodology.html">Methodology</a></li>
 											<li><a href="resources.html">Eviction help</a></li>
 											<li><a href="mailto:evictions@berkeley.edu?Subject=Contact%20through%20Evictions%20Study%20website">Contact us</a></li>
+											<li><a href="research.html">Other Research</a></li>
                       <!--<li><a href="">State Maps</a></li>
 											<li><a href="">Reports</a></li>
 											<li><a href="news.html">News</a></li>
-                      <li><a href="research.html">Research</a></li>
                       <li><a href="about.html">About</a></li>-->
 										</ul>
 									</div>


### PR DESCRIPTION
@timathomas I completed the to-do list [here](https://github.com/evictionresearch/evictionresearch.github.io/pull/32#event-7665138096) and also added the "Other Research" tab to all the current pages' HTML files (Home, Methodology, Eviction Help) because it wasn't showing up yet despite the merge.

I'm also going to add the tab to each individual `index.html` file for each state repo, because as of now this is the only way we know how to make it show up on each of these pages, but Hannah added a bullet [here](https://github.com/evictionresearch/evictions-template/issues/41) about creating a universal header that doesn't have to be updated in each page's HTML, because it'll be a ton of work to have to do this for every single state moving forward.